### PR TITLE
Upgrade Ubuntu version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Released under the MIT license
 # https://opensource.org/licenses/MIT
 
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 MAINTAINER Futa HIRAKOBA
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## 問題
Ubuntu 18.04は古い Linux ディストリビューションにあたるため、DevContainer環境での実行時にWarningが出ます。

参考: https://code.visualstudio.com/docs/remote/faq#_can-i-run-vs-code-server-on-older-linux-distributions

## 実行結果
[korosuke613/texlive-ja-devcontainer-template](https://github.com/korosuke613/texlive-ja-devcontainer-template) を実行した結果:
<img width="451" alt="スクリーンショット 2024-12-02 18 10 05" src="https://github.com/user-attachments/assets/03b958c5-38d9-4804-972b-1fe0bdd8cb04">

## 修正
ubuntuのバージョンを22.04にアップグレードしました。

## 動作検証
下記の方法で実施しました。
1. [korosuke613/texlive-ja-devcontainer-template](https://github.com/korosuke613/texlive-ja-devcontainer-template)を開く
2. Dockerfileとdocker-compose.ymlを以下のように変更する
3. DevContainersで実行する(ビルドに5分以上かかります)


<details><summary>Dockerfile</summary>
<p>

```
# Copyright (c) 2019 Futa HIRAKOBA
# Released under the MIT license
# https://opensource.org/licenses/MIT

FROM ubuntu:22.04 as base

MAINTAINER Futa HIRAKOBA
ENV DEBIAN_FRONTEND=noninteractive

RUN apt-get update && apt-get install -y \
    xdvik-ja \ 
    evince \
    texlive-lang-cjk \
    latexmk \
    language-pack-ja \
    wget \
    xzdec \
    texlive-latex-extra \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*

RUN tlmgr init-usertree
RUN kanji-config-updmap-sys ipaex

WORKDIR /workdir

VOLUME ["/workdir"]

CMD ["bash"]

FROM base

MAINTAINER Futa HIRAKOBA

RUN apt-get update && apt-get install -y \
    git \
    cpanminus \
    texlive-extra-utils \
    make \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/*

RUN cpanm Log::Log4perl Log::Dispatch::File YAML::Tiny File::HomeDir Unicode::GCString
```

</p>
</details> 

<details><summary>docker-compose.yml</summary>
<p>

```yaml
version: "3"
services:
  ubuntu-texlive-ja:
    build: .
    command: sleep infinity
    volumes:
      - ../:/workdir
      - ~/.gitconfig:/root/.gitconfig
      - ./.latexmkrc:/root/.latexmkrc
    environment:
      SHELL: "/bin/bash"
```

</p>
</details> 
